### PR TITLE
docs: add personas, RACI matrix, and checklists to improve role clarity (#4)

### DIFF
--- a/docs/checklists/release-readiness-checklist.md
+++ b/docs/checklists/release-readiness-checklist.md
@@ -1,0 +1,23 @@
+# Release Readiness Checklist
+
+Purpose: Ensure releases are safe, observable, and properly communicated.
+
+Pre-release
+- [ ] All acceptance criteria met and verified
+- [ ] PRs merged and CI green
+- [ ] Security and dependency scans completed
+- [ ] Release notes drafted (owner: PdM)
+- [ ] Rollback / mitigation plan documented (owner: DevOps/PM)
+- [ ] Staging smoke tests passed (owner: QA/Dev)
+
+Release day
+- [ ] Deployment window and owners confirmed (owner: PM)
+- [ ] Backups/snapshots (if applicable)
+- [ ] Execute deployment via CI/CD pipeline (owner: DevOps)
+- [ ] Post-deploy smoke tests executed (owner: QA/Dev)
+- [ ] Notify stakeholders and support channels of release (owner: PM/PdM)
+
+Post-release
+- [ ] Monitor dashboards for errors/latency (owner: DevOps/Data Analyst)
+- [ ] Validate success metrics (owner: PdM/Data Analyst)
+- [ ] Capture any follow-ups/action items (owner: PM)

--- a/docs/checklists/role-onboarding-checklist.md
+++ b/docs/checklists/role-onboarding-checklist.md
@@ -1,0 +1,13 @@
+# Role Onboarding Checklist
+
+Purpose: Ensure new role assignments or new teammates have consistent setup and clarity.
+
+- [ ] Role holder introduced to the project and core stakeholders
+- [ ] Role responsibilities and decision authority documented in project README
+- [ ] Access granted: repo, CI, dashboards, issue tracker, slack/channel
+- [ ] Key artifacts linked: Project One-pager, Roadmap, Risk Register
+- [ ] Onboarding session scheduled with PdM and PM (context + priorities)
+- [ ] Technical walkthrough (for Dev/DevOps) or research/analytics context (for UX/Data)
+- [ ] Communication expectations documented (meeting cadence, reports)
+- [ ] Immediate 30/60/90 day goals agreed
+- [ ] Mentor / point-of-contact assigned for first 2–4 weeks

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,100 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## Scrum Master
+
+### Role Summary
+Facilitates agile ceremonies, removes impediments, and drives continuous improvement for the delivery team.
+
+### Responsibilities
+- Facilitate sprint planning, daily standups, sprint reviews, and retrospectives
+- Help resolve or escalate blockers and impediments
+- Coach the team on agile principles and healthy team practices
+- Support continuous improvement and flow (minimize context switching)
+
+### Interaction with existing roles
+- Works closely with Project Managers to coordinate cadence and remove delivery impediments
+- Partners with Product Managers to improve flow and ensure the team is set up to deliver prioritized work
+- Supports Developers and QA by protecting team focus and helping surface technical/process issues
+
+---
+
+## UX Designer / Researcher
+
+### Role Summary
+Ensures user needs and experiences are incorporated throughout the project lifecycle.
+
+### Responsibilities
+- Conduct user research, usability testing, and gather customer feedback
+- Translate findings into actionable requirements, wireframes, and designs
+- Collaborate on accessibility and usability acceptance criteria
+- Validate designs with prototypes or lightweight experiments
+
+### Interaction with existing roles
+- Works with Product Managers to shape priorities and success criteria
+- Collaborates with Developers to ensure designs are feasible and implemented with accessibility in mind
+- Shares research artifacts and recommendations in project planning and reviews
+
+---
+
+## DevOps Engineer
+
+### Role Summary
+Automates infrastructure, CI/CD pipelines, and supports reliable delivery and deployment.
+
+### Responsibilities
+- Design, maintain, and improve build/test/deploy automation and pipelines
+- Monitor production systems, set up alerts, and respond to incidents
+- Collaborate on security, compliance, performance, and observability
+- Support release orchestration and rollback plans
+
+### Interaction with existing roles
+- Partners with Developers on build and deployment automation
+- Works with Project Managers to plan releases and define deployment windows
+- Collaborates with QA on test environments and production validation steps
+
+---
+
+## Data Analyst
+
+### Role Summary
+Delivers insights and data-driven recommendations to inform product and project decisions.
+
+### Responsibilities
+- Track and report key project and product metrics
+- Build and maintain dashboards and instrumentation guidance
+- Perform ad hoc analysis, experiments evaluation, and data validation
+
+### Interaction with existing roles
+- Works with Product Managers and Stakeholders to define and interpret success metrics
+- Partners with Developers for instrumentation, event definitions, and data quality
+- Supports Project Managers with metrics for progress and impact reporting
+
+---
+
+## Business Analyst
+
+### Role Summary
+Gathers requirements, maps processes, and supports alignment between business needs and technical solutions.
+
+### Responsibilities
+- Elicit and document stakeholder requirements and acceptance criteria
+- Analyze current workflows and identify improvement opportunities
+- Translate business needs into user stories, acceptance criteria, and clear specifications
+
+### Interaction with existing roles
+- Interfaces with Product and Project Managers to clarify needs and priorities
+- Works with Developers and QA to ensure requirements are testable and feasible
+- Engages stakeholders to validate scope and acceptance
+
+---
+
+## QA / Testing (existing note)
+
+(Keep existing QA/testing guidance; add role-specific interactions as needed.)
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-

--- a/docs/role-responsibility-matrix.md
+++ b/docs/role-responsibility-matrix.md
@@ -1,0 +1,21 @@
+# Role Responsibility Matrix (RACI) — OctoAcme
+
+Purpose: A quick reference to clarify who is Responsible, Accountable, Consulted, and Informed for common project activities.
+
+Legend: R = Responsible, A = Accountable, C = Consulted, I = Informed
+
+| Activity / Artifact                     | PdM | PM | Dev | QA | Scrum Master | UX | DevOps | Data Analyst | BA | Stakeholders |
+|-----------------------------------------|-----|----|-----|----|--------------|----|--------|--------------|----|--------------|
+| Project One-pager / Charter             | A   | R  | C   | I  | C            | C  | I      | C            | C  | I            |
+| Backlog Prioritization                  | A   | C  | C   | C  | C            | C  | I      | C            | C  | I            |
+| Sprint Planning & Commitment            | C   | R  | R   | C  | A            | C  | I      | I            | C  | I            |
+| Feature Design & UX                     | C   | I  | C   | C  | C            | A  | I      | C            | C  | I            |
+| Implementation & Code Delivery          | I   | R  | A   | C  | C            | C  | C      | I            | I  | I            |
+| Release & Deployment                    | I   | A  | R   | C  | C            | I  | A      | I            | I  | I            |
+| Incident Response / On-call            | I   | R  | R   | C  | C            | I  | R      | C            | I  | I            |
+| Metrics & Success Reporting             | A   | R  | C   | C  | I            | C  | I      | A            | C  | I            |
+| Requirements Gathering                  | C   | R  | C   | C  | C            | C  | I      | C            | A  | C            |
+
+Notes:
+- Use this as a starting point; adapt per project.
+- Ensure every activity has a named A (Accountable) for clarity.


### PR DESCRIPTION
Summary: Adds Scrum Master, UX/Researcher, DevOps Engineer, Data Analyst, and Business Analyst to docs/octoacme-roles-and-personas.md. Adds a Role Responsibility Matrix and two checklists (role onboarding, release readiness). These changes address gaps in role clarity, handoffs, and release processes requested in issue #4.
Linked issue: Fixes/Refs #4 (choose "Refs #4" if you don't want auto-close; use "Closes #4" to close)
Reviewers: @anilkumarpatcha
Notes: Please review the RACI table for project-specific adjustments and verify owners for your teams.